### PR TITLE
Simplify.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,15 +7,7 @@
 
 'use strict';
 
-// see http://jsperf.com/testing-value-is-primitive/5
+// see http://jsperf.com/testing-value-is-primitive/7
 module.exports = function isPrimitive(value) {
-  switch (typeof value) {
-    case "string":
-    case "number":
-    case "boolean":
-    case "symbol":
-      return true;
-    }
-
-  return value == null;
+  return value == null || (typeof value !== 'function' && typeof value !== 'object');
 };


### PR DESCRIPTION
This is a simpler check, a faster check, avoids a switch (those are gross), and will automatically be extensible if new "typeof" values are added in the future.

see http://jsperf.com/testing-value-is-primitive/7 - of course, micro-benchmarks are silly and don't cover real world use cases, so it's pretty irrelevant. Note that on Safari, `isPrimitive_or` is fastest, as opposed to the switch alternatives, which are way slower - and "simple" is the fastest overall, second only to the regex approach in firefox which is insanely fast because of it's weird regex implementation.
