### PR TITLE
Removed switch case

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const types = {
+var types = {
   boolean: true,
   number: true,
   string: true,

--- a/index.js
+++ b/index.js
@@ -7,16 +7,14 @@
 
 'use strict';
 
+const types = {
+  boolean: true,
+  number: true,
+  string: true,
+  symbol: true,
+  undefined: true,
+};
+
 module.exports = function isPrimitive(val) {
-  switch (typeof val) {
-    case 'boolean':
-    case 'number':
-    case 'string':
-    case 'symbol':
-    case 'undefined':
-      return true;
-    default: {
-      return val === null;
-    }
-  }
+  return  types[typeof val] ? true : val === null;
 };


### PR DESCRIPTION
Using switch cases is not a good practice, in Javascript we can have this beautiful solution to avoid the switch case, it is more readable and extensible