### PR TITLE
Micro-optimization: Changed switch to ifs, added benchmarks

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -21,6 +21,7 @@ const values = [
 ];
 
 suite
+  .add('if', () => values.map(v => isPrimitiveIf(v)))
   .add('switch', () => values.map(v => isPrimitiveSwitch(v)))
   .add('object', () => values.map(v => isPrimitiveObjectLookup(v)))
   .add('object - in', () => values.map(v => isPrimitiveObjectIn(v)))
@@ -76,10 +77,23 @@ function isPrimitiveSwitch(val) {
   }
 }
 
-// switch x 3,104,738 ops/sec ±0.61% (90 runs sampled)
-// object x 1,947,977 ops/sec ±0.55% (92 runs sampled)
-// object - in x 2,160,225 ops/sec ±0.63% (89 runs sampled)
-// object - own x 2,376,049 ops/sec ±0.59% (88 runs sampled)
-// array x 1,441,834 ops/sec ±0.54% (84 runs sampled)
-// equals x 2,983,937 ops/sec ±0.59% (87 runs sampled)
-// Fastest is switch
+function isPrimitiveIf(val) {
+  if (val === null
+    || typeof val === 'boolean'
+    || typeof val === 'number'
+    || typeof val === 'string'
+    || typeof val === 'symbol'
+    || typeof val === 'undefined') {
+    return true;
+  }
+  return false;
+}
+
+// if x 2,592,812 ops/sec ±0.79% (85 runs sampled)
+// switch x 2,490,420 ops/sec ±0.75% (83 runs sampled)
+// object x 1,474,088 ops/sec ±0.89% (83 runs sampled)
+// object - in x 1,658,439 ops/sec ±1.65% (83 runs sampled)
+// object - own x 1,823,545 ops/sec ±1.13% (84 runs sampled)
+// array x 1,156,344 ops/sec ±0.71% (86 runs sampled)
+// equals x 2,275,954 ops/sec ±0.74% (86 runs sampled)
+// Fastest is if

--- a/index.js
+++ b/index.js
@@ -8,15 +8,12 @@
 'use strict';
 
 module.exports = function isPrimitive(val) {
-  switch (typeof val) {
-    case 'boolean':
-    case 'number':
-    case 'string':
-    case 'symbol':
-    case 'undefined':
-      return true;
-    default: {
-      return val === null;
-    }
+  if (val === null
+    || typeof val === 'boolean'
+    || typeof val === 'number'
+    || typeof val === 'string'
+    || typeof val === 'symbol'
+    || typeof val === 'undefined') {
+    return true;
   }
 };


### PR DESCRIPTION
This is *slightly* faster than the switch-case. Here's the test results, just you know they got ran:

```
  isPrimitive
    ✓ should return true when primitive value
    ✓ should return false when not primitive value


  2 passing (9ms)
```

Benchmarks are slightly faster. The differences are statistically significant according to `benchmark`. No offense taken if you decide that the switch-case is elegant enough to prefer over a tiny speed increase. Here's the benchmarks for visibility:

```
is-primitive$ node bench.js
if x 2,548,250 ops/sec ±0.88% (88 runs sampled)
switch x 2,458,255 ops/sec ±0.74% (87 runs sampled)
object x 1,502,915 ops/sec ±0.89% (84 runs sampled)
object - in x 1,725,589 ops/sec ±0.86% (87 runs sampled)
object - own x 1,870,078 ops/sec ±0.87% (84 runs sampled)
array x 1,172,632 ops/sec ±0.73% (86 runs sampled)
equals x 2,397,364 ops/sec ±0.62% (87 runs sampled)
Fastest is if
```